### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -18,7 +18,7 @@ jobs:
       run: docker build . --file base/Dockerfile --tag nodered-openhab-bool-calc:latest
   
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         workdir: base
         name: majortwip/nodered-openhab-bool-calc


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore